### PR TITLE
Improve tests and introduce dead letter queues and some logging

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -80,6 +80,10 @@ type ConsumerOptions struct {
 	// Automatically try to unregister consumer from streams when shutting down
 	// Default false
 	UnregisterOnShutdown bool
+	//
+	// SkipReclaimAfter
+	// Default 5
+	SkipReclaimAfter uint
 }
 
 // Consumer adds a convenient wrapper around dequeuing and managing concurrency.
@@ -112,6 +116,7 @@ var defaultConsumerOptions = &ConsumerOptions{
 	Concurrency:       10,
 	PruneTimeout:      24 * time.Hour,
 	UsePreflightCheck: true,
+	SkipReclaimAfter:  5,
 }
 
 // NewConsumer uses a default set of options to create a Consumer. It sets Name
@@ -140,6 +145,9 @@ func NewConsumerWithOptions(ctx context.Context, options *ConsumerOptions) (*Con
 	}
 	if options.ReclaimInterval == 0 {
 		options.ReclaimInterval = 1 * time.Second
+	}
+	if options.SkipReclaimAfter == 0 {
+		options.SkipReclaimAfter = 5
 	}
 
 	var r redis.UniversalClient
@@ -233,7 +241,7 @@ func (c *Consumer) Run(ctx context.Context) {
 	}
 
 	go c.reclaim(ctx)
-	go c.poll()
+	go c.poll(ctx)
 
 	stop := newSignalHandler()
 	go func() {
@@ -244,7 +252,7 @@ func (c *Consumer) Run(ctx context.Context) {
 	c.wg.Add(c.options.Concurrency)
 
 	for i := 0; i < c.options.Concurrency; i++ {
-		go c.work()
+		go c.work(ctx)
 	}
 
 	// blocking, waiting for shutdown
@@ -430,9 +438,12 @@ func (c *Consumer) reclaim(ctx context.Context) {
 
 					for _, r := range res {
 						if r.Idle >= c.options.VisibilityTimeout {
-							l.WithField("message-id", r.ID).
+							lr := l.WithField("message-id", r.ID).
 								WithField("retry-count", r.RetryCount).
-								WithField("consumer", r.Consumer).Info("trying to reclaim message")
+								WithField("consumer", r.Consumer).
+								WithField("stream", stream)
+
+							lr.Info("trying to reclaim message")
 
 							claimres, err := c.redis.XClaim(context.Background(), &redis.XClaimArgs{
 								Stream:   stream,
@@ -461,11 +472,17 @@ func (c *Consumer) reclaim(ctx context.Context) {
 									continue
 								}
 							}
-							c.enqueue(stream, claimres)
+
 							for _, cm := range claimres {
-								l.WithField("message-id", cm.ID).
-									WithField("retry-count", r.RetryCount).
-									WithField("consumer", r.Consumer).Info("reclaiming message")
+								if r.RetryCount > int64(c.options.SkipReclaimAfter) {
+									lr.Warn("moving message to dead letter queue")
+									err = c.dlq(context.Background(), stream, cm)
+									if err != nil {
+										c.Errors <- errors.Wrapf(err, "error moving message to dlq for %q stream and %q message", stream, r.ID)
+									}
+									continue
+								}
+								c.requeue(stream, cm, uint(r.RetryCount))
 							}
 						}
 					}
@@ -483,17 +500,40 @@ func (c *Consumer) reclaim(ctx context.Context) {
 	}
 }
 
+// dlq add message to dead letter queue
+func (c *Consumer) dlq(ctx context.Context, stream string, msg redis.XMessage) error {
+	args := &redis.XAddArgs{
+		ID:     msg.ID,
+		Stream: "dlq-" + stream,
+		Values: msg.Values,
+	}
+	_, err := c.redis.XAdd(ctx, args).Result()
+	if err != nil {
+		return err
+	}
+	err = c.redis.XAck(context.Background(), stream, c.options.GroupName, msg.ID).Err()
+	if err != nil {
+		return err
+	}
+	err = c.redis.XDel(context.Background(), stream, msg.ID).Err()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // poll constantly checks the streams using XREADGROUP to see if there are any
 // messages for this consumer to process. It blocks for up to 5 seconds instead
 // of blocking indefinitely so that it can periodically check to see if Shutdown
 // was called.
-func (c *Consumer) poll() {
+func (c *Consumer) poll(ctx context.Context) {
 	for {
 		select {
 		case <-c.stopPoll:
 			// once the polling has stopped (i.e. there will be no more messages
 			// put onto c.queue), stop all of the workers
 			for i := 0; i < c.options.Concurrency; i++ {
+				logger.FromContext(ctx).Debugf("stopping worker: %d", i)
 				c.stopWorkers <- struct{}{}
 			}
 			return
@@ -536,27 +576,42 @@ func (c *Consumer) enqueue(stream string, msgs []redis.XMessage) {
 	}
 }
 
+// requeue takes a XMessage, creates corresponding Message, and sends
+// them on the centralized channel for worker goroutines to process.
+func (c *Consumer) requeue(stream string, xmsg redis.XMessage, retryCount uint) {
+	msg := &Message{
+		ID:         xmsg.ID,
+		Stream:     stream,
+		Values:     xmsg.Values,
+		RetryCount: retryCount,
+	}
+	c.queue <- msg
+}
+
 // work is called in a separate goroutine. The number of work goroutines is
 // determined by Concurreny. Once it gets a message from the centralized
 // channel, it calls the corrensponding ConsumerFunc depending on the stream it
 // came from. If no error is returned from the ConsumerFunc, the message is
 // acknowledged in Redis.
-func (c *Consumer) work() {
+func (c *Consumer) work(ctx context.Context) {
 	defer c.wg.Done()
-
+	l := logger.FromContext(ctx)
 	for {
 		select {
 		case msg := <-c.queue:
+			lm := l.WithField("message-id", msg.ID).WithField("stream", msg.Stream)
 			err := c.process(msg)
 			if err != nil {
 				c.Errors <- errors.Wrapf(err, "error calling ConsumerFunc for %q stream and %q message", msg.Stream, msg.ID)
 				continue
 			}
+			lm.Debug("processed message successfully")
 			err = c.redis.XAck(context.Background(), msg.Stream, c.options.GroupName, msg.ID).Err()
 			if err != nil {
 				c.Errors <- errors.Wrapf(err, "error acknowledging after success for %q stream and %q message", msg.Stream, msg.ID)
 				continue
 			}
+			lm.Debug("acknowledged message")
 		case <-c.stopWorkers:
 			return
 		}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -63,7 +63,8 @@ func TestNewConsumerWithOptions(t *testing.T) {
 
 	t.Run("bubbles up errors", func(tt *testing.T) {
 		_, err := NewConsumerWithOptions(context.Background(), &ConsumerOptions{
-			RedisOptions: &RedisOptions{Addr: "localhost:0"},
+			RedisOptions:      &RedisOptions{Addr: "localhost:0"},
+			UsePreflightCheck: true,
 		})
 		require.Error(tt, err)
 

--- a/message.go
+++ b/message.go
@@ -4,7 +4,8 @@ package redisqueue
 // When enqueuing, it's recommended to leave ID empty and let Redis generate it,
 // unless you know what you're doing.
 type Message struct {
-	ID     string
-	Stream string
-	Values map[string]interface{}
+	ID         string
+	Stream     string
+	Values     map[string]interface{}
+	RetryCount uint
 }

--- a/producer_test.go
+++ b/producer_test.go
@@ -39,7 +39,8 @@ func TestNewProducerWithOptions(t *testing.T) {
 
 	t.Run("bubbles up errors", func(tt *testing.T) {
 		_, err := NewProducerWithOptions(context.Background(), &ProducerOptions{
-			RedisOptions: &RedisOptions{Addr: "localhost:0"},
+			RedisOptions:      &RedisOptions{Addr: "localhost:0"},
+			UsePreflightCheck: true,
 		})
 		require.Error(tt, err)
 


### PR DESCRIPTION
Add config for when messages should be moved out of the queue and put on a dlq 
Add logging for when we reclaim and retry messages that have failed
Add tests for the new functionality